### PR TITLE
Redis driver lazily connects to Redis server

### DIFF
--- a/tests/Stash/Test/Driver/RedisArrayTest.php
+++ b/tests/Stash/Test/Driver/RedisArrayTest.php
@@ -58,9 +58,10 @@ class RedisArrayTest extends RedisTest
     {
         $driver = $this->getFreshDriver();
         $class = new \ReflectionClass($driver);
-        $redisProperty = $class->getProperty('redis');
-        $redisProperty->setAccessible(true);
-        $redisArray = $redisProperty->getValue($driver);
+
+        $redisClient = $class->getMethod('getRedisClient');
+        $redisClient->setAccessible(true);
+        $redisArray = $redisClient->invoke($driver);
 
         $this->assertInstanceOf('\RedisArray', $redisArray);
     }


### PR DESCRIPTION
Instead of instantiating a `\Redis` or `\RedisArray` instance upon instantiation, `\Stash\Driver\Redis` now waits until it tries to use the connection. We do this by inserting a `getRedisClient()` method call into each place that we previously referenced `$this->redis`.
